### PR TITLE
Normalize event.  

### DIFF
--- a/d2l-hierarchical-view-behavior.html
+++ b/d2l-hierarchical-view-behavior.html
@@ -230,8 +230,8 @@
 		},
 
 		__getParentViewFromEvent: function(e) {
-			var path = e.path;
-			for (var i = 1; i < e.path.length; i++) {
+			var path = Polymer.dom(e).path;
+			for (var i = 1; i < path.length; i++) {
 				if (path[i].isHierarchicalView) {
 					return path[i];
 				}

--- a/demo/hierarchical-view.html
+++ b/demo/hierarchical-view.html
@@ -3,8 +3,11 @@
 	<title>D2L Hierarchical View Web Component</title>
 	<script src="https://s.brightspace.com/lib/webcomponentsjs/0.7.21/webcomponents.min.js"></script>
 	<script>
-		//window.Polymer = window.Polymer || {};
-		//window.Polymer.dom = 'shadow';
+		var shadow = (window.location.search.indexOf('dom=shadow') > -1);
+		if (shadow) {
+			window.Polymer = window.Polymer || {};
+			window.Polymer.dom = 'shadow';
+		}
 	</script>
 	<link rel="stylesheet" href="demo-styles.css">
 	<link rel="import" href="../d2l-hierarchical-view.html">


### PR DESCRIPTION
This fixes JS error for IE10 where event path is undefined/null when opening d2l-dropdown-menu.

Polymer.dom() should almost always be used to normalize event for retargeting where shadow DOM is not supported.